### PR TITLE
add bufdelete

### DIFF
--- a/lua/VisualStudioNeovim/Core/plugins.lua
+++ b/lua/VisualStudioNeovim/Core/plugins.lua
@@ -52,6 +52,8 @@ return packer.startup(function(use)
   use "kyazdani42/nvim-tree.lua"
   -- BufferLine
   use "akinsho/bufferline.nvim"
+  -- Buffer delete commands
+  use "famiu/bufdelete.nvim"
   -- LuaLine ( status bar )
   use "nvim-lualine/lualine.nvim"
   -- Terminal


### PR DESCRIPTION
Bufferline uses `Bdelete!` to close buffers. 

But `bufdelete.nvim` is not installed.

This PR fixes that.